### PR TITLE
Set ByoHost status to K8sNodeBootstrapSucceeded if /run/cluster-api/bootstrap-success.complete exists

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -99,6 +99,11 @@ func (r *HostReconciler) reconcileNormal(ctx context.Context, byoHost *infrastru
 		return ctrl.Result{}, nil
 	}
 
+	if _, err := os.Stat(bootstrapSentinelFile); err == nil {
+		logger.Info("Found sentinel file, setting BootstrapK8sNodeSucceeded condition to true")
+		conditions.MarkTrue(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded)
+	}
+
 	if !conditions.IsTrue(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded) {
 		bootstrapScript, err := r.getBootstrapScript(ctx, byoHost.Spec.BootstrapSecret.Name, byoHost.Spec.BootstrapSecret.Namespace)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Set ByoHost status to K8sNodeBootstrapSucceeded if /run/cluster-api/bootstrap-success.complete exists
It helps to make clusterctl move process more simple, without a need to issue CSRs and update ~/.byoh/config by yourself

**Additional information**
Relates to vmware-tanzu/cluster-api-provider-bringyourownhost#853


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->